### PR TITLE
fix: AM/PM parsing issue

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,17 +4,6 @@ function isGitHubActionsPage() {
 
 if (isGitHubActionsPage()) {
 
-function parseDateTime(dateTimeStr) {
-    // Remove parentheses and split the string
-    const parts = dateTimeStr.replace(/[()]/g, '').split(',');
-
-    // Combine the date and time parts and replace the GMT part
-    const formattedStr = `${parts[0]},${parts[1].trim()} ${parts[2].split(' ')[1]}`;
-    
-    // Parse the date
-    return new Date(formattedStr);
-}
-
 function formatDateTime(date) {
     // Format the date and time; you can adjust the format as needed
     return date.toLocaleString('en-US', { 
@@ -27,11 +16,6 @@ function formatDateTime(date) {
     });
 }
 
-function displayLocalTime(dateTimeStr) {
-    const date = parseDateTime(dateTimeStr);
-    return formatDateTime(date);
-}
-
 
 function updateRunTimeDisplay() {
     const timeElements = document.querySelectorAll('relative-time');
@@ -39,8 +23,8 @@ function updateRunTimeDisplay() {
     console.log('Found time elements:', timeElements.length); // Debugging line
 
     timeElements.forEach(el => {
-        const fullTime = el.getAttribute('title');
-        const localTime = displayLocalTime(fullTime);
+        const fullTime = el.getAttribute('datetime');
+        const localTime = formatDateTime(new Date(fullTime));
         if (fullTime && !el.classList.contains('full-time-updated')) {
             const newElement = document.createElement('div');
             newElement.textContent = `${localTime}`;


### PR DESCRIPTION
Some PM times were being parsed as AM. I circumvent the issue entirely by using the "datetime" attribute present on each `relative-time` element rather than trying to parse a non-standard datetime representation:
![image](https://github.com/jan0991/github-actions-full-datetime/assets/12461302/2b8c9776-d2e0-45e3-b5a6-e7520f08f6c6)



### Before
![image](https://github.com/jan0991/github-actions-full-datetime/assets/12461302/240645c4-ad03-4016-a82d-50c306eb891c)


### After
![image](https://github.com/jan0991/github-actions-full-datetime/assets/12461302/b833cb01-7342-496f-9837-2b500d92b19e)
